### PR TITLE
Komponent "Start" i "Ranking" #24 

### DIFF
--- a/src/components/MenuButton/MenuButton.js
+++ b/src/components/MenuButton/MenuButton.js
@@ -11,11 +11,7 @@ function MenuButton({ text, onClick, variant = 'normal', disabled = false }) {
     outlined: styles.menuButtonOutlined,
   };
 
-  const menuButton = html`<button
-    class="${classNamesForVariant[variant]}"
-    type="button"
-    ${disabled ? ' disabled aria-disabled="true"' : ''}
-  >
+  const menuButton = html`<button class="${classNamesForVariant[variant]}" type="button" ${disabled ? ' disabled' : ''}>
     ${text}
   </button>`;
   menuButton.addEventListener('click', onClick);

--- a/src/components/MenuButton/MenuButton.js
+++ b/src/components/MenuButton/MenuButton.js
@@ -2,25 +2,25 @@ import { html } from '../../shared';
 import styles from './MenuButton.module.css';
 
 /**
- * @param {{onClick: (e: MouseEvent) => void, text: string, variant?: 'normal' | 'outlined', disabled?: boolean }} props
+ * @param {{ text: string, onClick: (e: MouseEvent) => void, variant?: 'normal' | 'outlined', disabled?: boolean }} props
  * @returns {HTMLButtonElement}
  */
-function MenuButton({ onClick, text, variant, disabled }) {
-  const classNamesForStyle = {
-    normal: styles.btnNormal,
-    outlined: styles.btnOutlined,
+function MenuButton({ text, onClick, variant, disabled }) {
+  const classNamesForVariant = {
+    normal: styles.menuButtonNormal,
+    outlined: styles.menuButtonOutlined,
   };
 
-  const btn = html`<button
-    class="${classNamesForStyle[variant ?? 'normal']}"
+  const menuButton = html`<button
+    class="${classNamesForVariant[variant ?? 'normal']}"
     type="button"
     ${disabled ?? false ? ' disabled aria-disabled="true"' : ''}
   >
     ${text}
   </button>`;
-  btn.addEventListener('click', onClick);
+  menuButton.addEventListener('click', onClick);
   // @ts-ignore
-  return btn;
+  return menuButton;
 }
 
 export { MenuButton };

--- a/src/components/MenuButton/MenuButton.js
+++ b/src/components/MenuButton/MenuButton.js
@@ -1,0 +1,26 @@
+import { html } from '../../shared';
+import styles from './MenuButton.module.css';
+
+/**
+ * @param {{onClick: (e: MouseEvent) => void, text: string, variant?: 'normal' | 'outlined', disabled?: boolean }} props
+ * @returns {HTMLButtonElement}
+ */
+function MenuButton({ onClick, text, variant, disabled }) {
+  const classNamesForStyle = {
+    normal: styles.btnNormal,
+    outlined: styles.btnOutlined,
+  };
+
+  const btn = html`<button
+    class="${classNamesForStyle[variant ?? 'normal']}"
+    type="button"
+    ${disabled ?? false ? ' disabled aria-disabled="true"' : ''}
+  >
+    ${text}
+  </button>`;
+  btn.addEventListener('click', onClick);
+  // @ts-ignore
+  return btn;
+}
+
+export { MenuButton };

--- a/src/components/MenuButton/MenuButton.js
+++ b/src/components/MenuButton/MenuButton.js
@@ -5,16 +5,16 @@ import styles from './MenuButton.module.css';
  * @param {{ text: string, onClick: (e: MouseEvent) => void, variant?: 'normal' | 'outlined', disabled?: boolean }} props
  * @returns {HTMLButtonElement}
  */
-function MenuButton({ text, onClick, variant, disabled }) {
+function MenuButton({ text, onClick, variant = 'normal', disabled = false }) {
   const classNamesForVariant = {
     normal: styles.menuButtonNormal,
     outlined: styles.menuButtonOutlined,
   };
 
   const menuButton = html`<button
-    class="${classNamesForVariant[variant ?? 'normal']}"
+    class="${classNamesForVariant[variant]}"
     type="button"
-    ${disabled ?? false ? ' disabled aria-disabled="true"' : ''}
+    ${disabled ? ' disabled aria-disabled="true"' : ''}
   >
     ${text}
   </button>`;

--- a/src/components/MenuButton/MenuButton.module.css
+++ b/src/components/MenuButton/MenuButton.module.css
@@ -1,0 +1,30 @@
+.btn {
+  font-size: var(--button-text);
+  height: 3.25rem;
+  padding: 0.625rem 1.6rem;
+  border-radius: 3.125rem;
+  color: var(--common-white);
+  transition-duration: 0.2s;
+}
+
+.btnNormal {
+  composes: btn;
+  background-color: var(--secondary-main);
+}
+
+.btnOutlined {
+  composes: btn;
+  border: 0.1875rem solid var(--secondary-main);
+}
+
+.btn:hover {
+  background-color: var(--secondary-dark);
+  border-color: transparent;
+}
+
+.btn:disabled {
+  color: rgba(255, 255, 255, 0.38);
+  background-color: rgba(255, 255, 255, 0.5);
+  border-color: transparent;
+  cursor: initial;
+}

--- a/src/components/MenuButton/MenuButton.module.css
+++ b/src/components/MenuButton/MenuButton.module.css
@@ -1,4 +1,4 @@
-.btn {
+.menuButton {
   font-size: var(--button-text);
   height: 3.25rem;
   padding: 0.625rem 1.6rem;
@@ -7,22 +7,22 @@
   transition-duration: 0.2s;
 }
 
-.btnNormal {
-  composes: btn;
+.menuButtonNormal {
+  composes: menuButton;
   background-color: var(--secondary-main);
 }
 
-.btnOutlined {
-  composes: btn;
+.menuButtonOutlined {
+  composes: menuButton;
   border: 0.1875rem solid var(--secondary-main);
 }
 
-.btn:hover {
+.menuButton:hover {
   background-color: var(--secondary-dark);
   border-color: transparent;
 }
 
-.btn:disabled {
+.menuButton:disabled {
   color: rgba(255, 255, 255, 0.38);
   background-color: rgba(255, 255, 255, 0.5);
   border-color: transparent;

--- a/src/components/MenuButton/MenuButton.test.js
+++ b/src/components/MenuButton/MenuButton.test.js
@@ -1,0 +1,39 @@
+import userEvent from '@testing-library/user-event';
+import { MenuButton } from './MenuButton';
+
+describe('MenuButton tests', () => {
+  it('should render text', () => {
+    // Given
+    const text = 'Test';
+    const menuButton = MenuButton({ text, onClick: () => {} });
+
+    // Then
+    expect(menuButton.textContent.trim()).toBe(text);
+  });
+
+  it('should handle clicks', () => {
+    // Given
+    const onClick = jest.fn();
+    const menuButton = MenuButton({ text: 'Click!', onClick, variant: 'outlined' });
+    expect(onClick).toHaveBeenCalledTimes(0);
+
+    // When
+    userEvent.click(menuButton);
+
+    // Then
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be disabled', () => {
+    // Given
+    const onClick = jest.fn();
+    const menuButton = MenuButton({ text: 'Disabled button', onClick, disabled: true });
+
+    // When
+    userEvent.click(menuButton);
+
+    // Then
+    expect(menuButton.disabled).toBe(true);
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/MenuButton/index.js
+++ b/src/components/MenuButton/index.js
@@ -1,2 +1,1 @@
-export * from './Button';
 export * from './MenuButton';


### PR DESCRIPTION
Przycisk menu głównego w dwóch wariantach:
- `normal` (np. "Rozpocznij quiz" z Figmy)
- `outlined` (np. "Ranking" z Figmy)

Przykłady zastosowania:
```JavaScript
// Rozpocznij quiz - zwykły
MenuButton({ text: 'Rozpocznij quiz', onClick: () => {} })
// Rozpocznij quiz - wyłączony
MenuButton({ text: 'Rozpocznij quiz', onClick: () => {}, disabled: true })
// Ranking
MenuButton({ text: 'Ranking', onClick: () => {}, variant: 'outlined' })
```

100% pokrycia komponentu testami.