### PR TITLE
Responsywność #69

### DIFF
--- a/src/components/AnswersTable/AnswersTable.js
+++ b/src/components/AnswersTable/AnswersTable.js
@@ -34,6 +34,7 @@ const answerImagesDiv = (answers, answersDiv) => {
     const characterImage = document.createElement('img');
     characterImage.src = character.image;
     characterImage.alt = character.name;
+    characterImage.title = character.name;
     characterImage.className = styles.answerImage;
     answersDiv.appendChild(characterImage);
   });
@@ -53,6 +54,7 @@ const characterQuestionElements = (count, answer) => {
 
   characterImage.src = answer.whatIsQuestionAbout;
   characterImage.alt = answer.correctAnswers[0].name;
+  characterImage.title = answer.correctAnswers[0].name;
   characterImage.className = styles.characterImage;
 
   return [questionNumber, characterImage, correctAnswer, userAnswer, correct];

--- a/src/components/AnswersTable/AnswersTable.module.css
+++ b/src/components/AnswersTable/AnswersTable.module.css
@@ -2,7 +2,7 @@
   --answer-image-size: 2rem;
   --answer-image-margin: 0.5rem;
 
-  height: 15rem;
+  height: 12rem;
   margin-bottom: 1rem;
   overflow: auto;
   max-width: 100%;
@@ -19,7 +19,6 @@
   background-color: var(--primary-dark);
   border-radius: 0;
   padding: 0.25rem 0.5rem;
-  white-space: nowrap;
   position: sticky;
   top: 0;
   z-index: 1;

--- a/src/components/AnswersTable/AnswersTable.module.css
+++ b/src/components/AnswersTable/AnswersTable.module.css
@@ -1,40 +1,34 @@
-:root {
-  --answer-image-size: 3.1rem;
-  --answer-image-margin: 0.5rem;
-}
-
 .answersWrapper {
-  height: 22.85rem;
-  margin-bottom: 1.5rem;
-  overflow-y: auto;
+  --answer-image-size: 2rem;
+  --answer-image-margin: 0.5rem;
+
+  height: 15rem;
+  margin-bottom: 1rem;
+  overflow: auto;
+  max-width: 100%;
 }
 
 .answersTable {
-  width: 62.8rem;
   border-collapse: separate;
-  border-spacing: 0 0.15rem;
+  border-spacing: 0 0.2rem;
   font-size: var(--question-text);
+  text-align: center;
 }
 
 .answersTable thead th {
-  color: var(--common-white);
   background-color: var(--primary-dark);
   border-radius: 0;
+  padding: 0.25rem 0.5rem;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
   z-index: 1;
 }
 
-.tableRow {
-  height: 5.6rem;
-  vertical-align: middle;
-  background-color: var(--action-active);
-  border-radius: 10px;
-}
-
 .tableCell {
-  width: 17.2rem;
   position: relative;
-  padding-left: 0.4rem;
-  padding-right: 0.4rem;
+  background-color: var(--action-active);
+  padding: 0.25rem 0.5rem;
 }
 
 .tableCell:not(:last-child)::after {
@@ -47,28 +41,24 @@
   background-color: var(--common-white);
 }
 
-.tableCell:first-child, .tableCell:last-child {
-  width: 5.6rem;
-}
-
-.tableCell:first-child {
-  border-radius: 10px 0 0 10px;
-  color: var(--primary-light);
-}
-
+.tableCell:first-child,
 .tableCell:nth-child(2) {
   color: var(--primary-light);
 }
 
+.tableCell:first-child {
+  border-radius: 0.5rem 0 0 0.5rem;
+}
+
 .tableCell:last-child {
-  border-radius: 0 10px 10px 0;
+  border-radius: 0 0.5rem 0.5rem 0;
 }
 
 .characterImage {
   display: block;
-  margin: auto;
-  height: 5.3rem;
-  width: 5.3rem;
+  margin: 0 auto;
+  width: var(--answer-image-size);
+  height: var(--answer-image-size);
   border-radius: 20%;
 }
 
@@ -90,4 +80,6 @@
 
 .correctIcon {
   margin: auto;
+  height: var(--answer-image-size);
+  min-width: var(--answer-image-size);
 }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,11 +1,12 @@
 .Button {
   font-size: var(--button-text);
-  padding: 0.75rem 1.6rem;
-  border: 6px solid transparent;
+  padding: 0.45rem 1rem;
+  border: 0.1875rem solid transparent;
   border-radius: var(--default-border-radius);
   color: var(--common-white);
   transition: var(--default-transition);
   line-height: 1;
+  white-space: nowrap;
 }
 
 .Button:hover {
@@ -28,7 +29,6 @@
 .ButtonMain {
   composes: Button;
   background-color: var(--secondary-main);
-  width: 100%;
 }
 
 .ButtonMain:hover {
@@ -38,7 +38,6 @@
 .ButtonOutlined {
   composes: Button;
   border-color: var(--secondary-main);
-  width: 100%;
 }
 
 .ButtonOutlined:hover {
@@ -63,7 +62,6 @@
 .ButtonGameMode {
   composes: Button;
   border-color: var(--primary-main);
-  width: 100%;
 }
 
 .ButtonGameMode:hover {

--- a/src/components/ContentWrapper/ContentWrapper.js
+++ b/src/components/ContentWrapper/ContentWrapper.js
@@ -1,0 +1,53 @@
+import { html } from '../../shared';
+import headImg from '../../public/img/RicksHead.png';
+import logoImg from '../../public/img/RickAndMortyLogo.png';
+import { BackgroundDecoration } from '../BackgroundDecoration';
+import styles from './ContentWrapper.module.css';
+
+/**
+ *
+ * @param {{
+ *  hasHead?: boolean,
+ *  hasLogo?: boolean,
+ *  hasBgDecoration?: boolean,
+ *  topLeft?: string | HTMLElement,
+ *  topRight?: string | HTMLElement,
+ *  botRight?: string | HTMLElement,
+ *  content: string | HTMLElement
+ * }} props
+ * @returns {HTMLDivElement}
+ */
+function ContentWrapper({
+  hasHead = false,
+  hasLogo = false,
+  hasBgDecoration = false,
+  topLeft = '',
+  topRight = '',
+  botRight = '',
+  content,
+}) {
+  const head = html`<div class="${styles.headWrapper}"><img src="${headImg}" alt="Głowa Ricka." /></div>`;
+
+  const logo = html`<div class="${styles.logoWrapper}"><img src="${logoImg}" alt="Logo serialu." /></div>`;
+
+  const margins = `
+  margin-top: ${hasHead ? 'var(--panel-padding)' : '0'};
+  margin-bottom: ${hasLogo ? 'var(--panel-padding)' : '0'};
+  `;
+
+  return /** @type {HTMLDivElement} */ (
+    html`<div class="${styles.wrapper}">
+      ${hasBgDecoration ? BackgroundDecoration() : ''}
+      <section class="${styles.panel}" style="${margins}">
+        <div class="${styles.topLeft}">${topLeft}</div>
+        ${hasHead ? head : ''}
+        <div class="${styles.topRight}">${topRight}</div>
+        <main class="${styles.content}">${content}</main>
+        ${hasLogo ? logo : ''}
+        <div class="${styles.botRight}">${botRight}</div>
+      </section>
+    </div>`
+  );
+}
+
+export { ContentWrapper };

--- a/src/components/ContentWrapper/ContentWrapper.js
+++ b/src/components/ContentWrapper/ContentWrapper.js
@@ -13,6 +13,7 @@ import styles from './ContentWrapper.module.css';
  *  topLeft?: string | HTMLElement,
  *  topRight?: string | HTMLElement,
  *  botRight?: string | HTMLElement,
+ *  topAttachment?: string | HTMLElement,
  *  content: string | HTMLElement
  * }} props
  * @returns {HTMLDivElement}
@@ -24,13 +25,15 @@ function ContentWrapper({
   topLeft = '',
   topRight = '',
   botRight = '',
+  topAttachment = '',
   content,
 }) {
   const head = html`<div class="${styles.headWrapper}"><img src="${headImg}" alt="Głowa Ricka." /></div>`;
-
   const logo = html`<div class="${styles.logoWrapper}"><img src="${logoImg}" alt="Logo serialu." /></div>`;
 
-  const mTop = hasHead || topLeft !== '' || topRight !== '';
+  const hasAttachment = topAttachment !== '';
+
+  const mTop = hasHead || topLeft !== '' || topRight !== '' || hasAttachment;
   const mBot = hasLogo || botRight !== '';
 
   const margins = `
@@ -41,10 +44,11 @@ function ContentWrapper({
   return /** @type {HTMLDivElement} */ (
     html`<div class="${styles.wrapper}">
       ${hasBgDecoration ? BackgroundDecoration() : ''}
-      <section class="${styles.panel}" style="${margins}">
+      <section class="${hasAttachment ? styles.panelWithAttachment : styles.panel}" style="${margins}">
         <div class="${styles.topLeft}">${topLeft}</div>
         ${hasHead ? head : ''}
         <div class="${styles.topRight}">${topRight}</div>
+        ${hasAttachment ? html`<div class="${styles.topAttachment}">${topAttachment}</div>` : ''}
         <main class="${styles.content}">${content}</main>
         ${hasLogo ? logo : ''}
         <div class="${styles.botRight}">${botRight}</div>

--- a/src/components/ContentWrapper/ContentWrapper.js
+++ b/src/components/ContentWrapper/ContentWrapper.js
@@ -30,9 +30,12 @@ function ContentWrapper({
 
   const logo = html`<div class="${styles.logoWrapper}"><img src="${logoImg}" alt="Logo serialu." /></div>`;
 
+  const mTop = hasHead || topLeft !== '' || topRight !== '';
+  const mBot = hasLogo || botRight !== '';
+
   const margins = `
-  margin-top: ${hasHead ? 'var(--panel-padding)' : '0'};
-  margin-bottom: ${hasLogo ? 'var(--panel-padding)' : '0'};
+  margin-top: ${mTop ? 'var(--panel-padding)' : '0'};
+  margin-bottom: ${mBot ? 'var(--panel-padding)' : '0'};
   `;
 
   return /** @type {HTMLDivElement} */ (

--- a/src/components/ContentWrapper/ContentWrapper.js
+++ b/src/components/ContentWrapper/ContentWrapper.js
@@ -4,16 +4,20 @@ import logoImg from '../../public/img/RickAndMortyLogo.png';
 import { BackgroundDecoration } from '../BackgroundDecoration';
 import styles from './ContentWrapper.module.css';
 
+const head = html`<div class="${styles.headWrapper}"><img src="${headImg}" alt="Głowa Ricka." /></div>`;
+
+const logo = html`<div class="${styles.logoWrapper}"><img src="${logoImg}" alt="Logo serialu." /></div>`;
+
 /**
  *
  * @param {{
  *  hasHead?: boolean,
  *  hasLogo?: boolean,
  *  hasBgDecoration?: boolean,
- *  topLeft?: string | HTMLElement,
- *  topRight?: string | HTMLElement,
- *  botRight?: string | HTMLElement,
- *  topAttachment?: string | HTMLElement,
+ *  topLeft?: HTMLElement,
+ *  topRight?: HTMLElement,
+ *  botRight?: HTMLElement,
+ *  topAttachment?: HTMLElement,
  *  content: string | HTMLElement
  * }} props
  * @returns {HTMLDivElement}
@@ -22,19 +26,14 @@ function ContentWrapper({
   hasHead = false,
   hasLogo = false,
   hasBgDecoration = false,
-  topLeft = '',
-  topRight = '',
-  botRight = '',
-  topAttachment = '',
+  topLeft,
+  topRight,
+  botRight,
+  topAttachment,
   content,
 }) {
-  const head = html`<div class="${styles.headWrapper}"><img src="${headImg}" alt="Głowa Ricka." /></div>`;
-  const logo = html`<div class="${styles.logoWrapper}"><img src="${logoImg}" alt="Logo serialu." /></div>`;
-
-  const hasAttachment = topAttachment !== '';
-
-  const mTop = hasHead || topLeft !== '' || topRight !== '' || hasAttachment;
-  const mBot = hasLogo || botRight !== '';
+  const mTop = hasHead || topLeft || topRight || topAttachment;
+  const mBot = hasLogo || botRight;
 
   const margins = `
   margin-top: ${mTop ? 'var(--panel-padding)' : '0'};
@@ -44,14 +43,12 @@ function ContentWrapper({
   return /** @type {HTMLDivElement} */ (
     html`<div class="${styles.wrapper}">
       ${hasBgDecoration ? BackgroundDecoration() : ''}
-      <section class="${hasAttachment ? styles.panelWithAttachment : styles.panel}" style="${margins}">
-        <div class="${styles.topLeft}">${topLeft}</div>
-        ${hasHead ? head : ''}
-        <div class="${styles.topRight}">${topRight}</div>
-        ${hasAttachment ? html`<div class="${styles.topAttachment}">${topAttachment}</div>` : ''}
+      <section class="${topAttachment ? styles.panelWithAttachment : styles.panel}" style="${margins}">
+        ${topLeft ? html`<div class="${styles.topLeft}">${topLeft}</div>` : ''} ${hasHead ? head : ''}
+        ${topRight ? html`<div class="${styles.topRight}">${topRight}</div>` : ''}
+        ${topAttachment ? html`<div class="${styles.topAttachment}">${topAttachment}</div>` : ''}
         <main class="${styles.content}">${content}</main>
-        ${hasLogo ? logo : ''}
-        <div class="${styles.botRight}">${botRight}</div>
+        ${hasLogo ? logo : ''} ${botRight ? html`<div class="${styles.botRight}">${botRight}</div>` : ''}
       </section>
     </div>`
   );

--- a/src/components/ContentWrapper/ContentWrapper.module.css
+++ b/src/components/ContentWrapper/ContentWrapper.module.css
@@ -12,6 +12,7 @@
 
 .panel {
   background-color: var(--primary-dark);
+  color: var(--common-white);
   border-radius: var(--default-border-radius);
   max-width: 70ch;
   display: grid;
@@ -26,6 +27,7 @@
 .content {
   grid-area: content;
   padding: 0 2rem;
+  min-width: 0px;
 }
 
 .logoWrapper {

--- a/src/components/ContentWrapper/ContentWrapper.module.css
+++ b/src/components/ContentWrapper/ContentWrapper.module.css
@@ -24,6 +24,12 @@
     '. logo bot-right';
 }
 
+.panelWithAttachment {
+  composes: panel;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .content {
   grid-area: content;
   padding: 0 2rem;
@@ -88,4 +94,13 @@
 .botRight {
   grid-area: bot-right;
   margin-bottom: var(--float-offset);
+}
+
+.topAttachment {
+  grid-area: 1 / 1 / 1 / -1;
+  margin-top: calc((-1) * var(--panel-padding));
+  padding-bottom: var(--panel-padding);
+  height: calc(2 * var(--panel-padding));
+  width: 100%;
+  z-index: 1;
 }

--- a/src/components/ContentWrapper/ContentWrapper.module.css
+++ b/src/components/ContentWrapper/ContentWrapper.module.css
@@ -14,6 +14,7 @@
   background-color: var(--primary-dark);
   color: var(--common-white);
   border-radius: var(--default-border-radius);
+  box-shadow: var(--popup-shadow);
   max-width: 70ch;
   display: grid;
   grid-template-rows: var(--panel-padding) auto var(--panel-padding);

--- a/src/components/ContentWrapper/ContentWrapper.module.css
+++ b/src/components/ContentWrapper/ContentWrapper.module.css
@@ -8,6 +8,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow-x: hidden;
 }
 
 .panel {

--- a/src/components/ContentWrapper/ContentWrapper.module.css
+++ b/src/components/ContentWrapper/ContentWrapper.module.css
@@ -1,0 +1,89 @@
+.wrapper {
+  --wrapper-padding: 1rem;
+  --panel-padding: 3rem;
+  --float-offset: -2rem;
+
+  min-height: 100vh;
+  padding: var(--wrapper-padding);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.panel {
+  background-color: var(--primary-dark);
+  border-radius: var(--default-border-radius);
+  max-width: 70ch;
+  display: grid;
+  grid-template-rows: var(--panel-padding) auto var(--panel-padding);
+  grid-template-columns: 1fr 50% 1fr;
+  grid-template-areas:
+    'top-left head top-right'
+    'content content content'
+    '. logo bot-right';
+}
+
+.content {
+  grid-area: content;
+  padding: 0 2rem;
+}
+
+.logoWrapper {
+  grid-area: logo;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.logoWrapper img {
+  margin-bottom: calc((-1) * var(--panel-padding));
+  max-height: calc(2 * var(--panel-padding));
+}
+
+.headWrapper {
+  grid-area: head;
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.headWrapper img {
+  position: absolute;
+  bottom: var(--panel-padding);
+  transform: translateY(15%);
+  max-height: 7.5rem;
+}
+
+.topLeft,
+.topRight,
+.botRight {
+  display: flex;
+  align-items: center;
+  position: sticky;
+  z-index: 1; /* Show above Rick's head if necessary */
+}
+
+.topLeft {
+  grid-area: top-left;
+  margin-top: var(--float-offset);
+  margin-left: var(--float-offset);
+  justify-content: start;
+  left: var(--wrapper-padding);
+}
+
+.topRight,
+.botRight {
+  margin-right: var(--float-offset);
+  justify-content: end;
+  right: var(--wrapper-padding);
+}
+
+.topRight {
+  grid-area: top-right;
+  margin-top: var(--float-offset);
+}
+
+.botRight {
+  grid-area: bot-right;
+  margin-bottom: var(--float-offset);
+}

--- a/src/components/ContentWrapper/index.js
+++ b/src/components/ContentWrapper/index.js
@@ -1,0 +1,1 @@
+export * from './ContentWrapper';

--- a/src/components/GameTypes/GameTypes.module.css
+++ b/src/components/GameTypes/GameTypes.module.css
@@ -3,23 +3,25 @@
   font-size: var(--header-3);
   color: var(--common-white);
   text-align: center;
-  width: 100%;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .container {
-  width: 39rem;
-  gap: 20px;
+  display: flex;
+  gap: 1rem;
 }
 
 .containerFullWidth {
-  display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
 }
 
 .containerHalfWidth {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.containerHalfWidth > * {
+  flex: 1;
 }
 
 .selectedType {

--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -1,11 +1,11 @@
 .input {
   font-size: var(--button-text);
-  padding: 0.625rem 1.6rem;
+  padding: 0.45rem 1rem;
   border-radius: var(--default-border-radius);
   color: var(--text-primary);
   transition-duration: var(--default-transition);
   outline: 0;
-  border: 2px solid transparent;
+  border: 0.1875rem solid transparent;
 }
 
 .input::placeholder {
@@ -18,5 +18,5 @@
 
 .input:focus {
   color: var(--secondary-dark);
-  border: 2px solid var(--secondary-light);
+  border-color: var(--secondary-light);
 }

--- a/src/components/PopupClose/PopupClose.module.css
+++ b/src/components/PopupClose/PopupClose.module.css
@@ -1,6 +1,6 @@
 .blobBox {
-  width: 6.125rem;
-  height: 6.125rem;
+  width: 5rem;
+  height: 5rem;
 
   display: grid;
   place-items: center;

--- a/src/components/PopupClose/PopupClose.module.css
+++ b/src/components/PopupClose/PopupClose.module.css
@@ -7,7 +7,7 @@
 }
 
 .blobBox > * {
-  grid-area: 1 / -1 / 1 / -1;
+  grid-area: 1 / 1 / -1 / -1;
 }
 
 .crossIcon {

--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -64,13 +64,13 @@ function Question(questionData) {
   const answers =
     category === 'character'
       ? questionData.answers.map(
-          (answer, index) => html`<div id="${index}" class="${styles.answer}">
+          (answer, index) => html`<div id="${index}" class="${styles.answer}" title="${answer.name}">
             <div class="${styles.answerItem}">${answerLetter[index]}</div>
             <p class="${styles.answerText}">${answer.name}</p>
           </div>`,
         )
       : questionData.answers.map(
-          (answer, index) => html`<div id="${index}" class="${styles.answer}">
+          (answer, index) => html`<div id="${index}" class="${styles.answer}" title="${answer.name}">
             <div class="${styles.answerItem}"><img src="${answer.image}" alt="${answer.name}" /></div>
             <p class="${styles.answerText}">${answer.name}</p>
           </div>`,

--- a/src/components/Question/Question.module.css
+++ b/src/components/Question/Question.module.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  color: var(--common-white);
   gap: 1rem;
 }
 

--- a/src/components/Question/Question.module.css
+++ b/src/components/Question/Question.module.css
@@ -9,6 +9,7 @@
   font-size: var(--header-3);
   font-weight: 800;
   text-align: center;
+  filter: drop-shadow(var(--heading-shadow));
 }
 
 .content {

--- a/src/components/Question/Question.module.css
+++ b/src/components/Question/Question.module.css
@@ -1,91 +1,95 @@
 .questionContainer {
-    width: 47.9rem;
-    margin-bottom: 1.6rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--common-white);
+  gap: 1rem;
 }
 
 .questionText {
-    margin-bottom: 0.8rem;
-    font-size: var(--header-3);
-    font-weight: 800;
-    text-align: center;
+  font-size: var(--header-3);
+  font-weight: 800;
+  text-align: center;
 }
 
 .content {
-    display: flex;
-    flex-direction: row;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
 .characterImageDiv {
-    width: 8.9rem;
-    height: 8.9rem;
-    margin-right: 1.8rem;
+  width: 8rem;
+  height: 8rem;
 }
 
 .characterImageDiv img {
-    width: 100%;
-    object-fit: cover;
-    border-radius: 20px;
-    box-shadow: black 0px 3px 8px;
+  width: 100%;
+  object-fit: cover;
+  border-radius: 1.25rem;
+  box-shadow: black 0px 3px 8px;
 }
 
 .answersContainer {
-    width: 37.05rem;
-    height: 9rem;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(calc(50% - 0.5rem), 20ch));
+  place-items: center start;
+  gap: 1rem;
+}
+
+@media (max-width: 576px) {
+  .answersContainer {
+    grid-template-columns: 1fr;
+  }
 }
 
 .answer {
-    width: 17.5rem;
-    height: 3.2rem;
-    margin-right: 1.8rem;
-    display: flex;
-    flex-basis: 45%;
-    align-items: center;
-    transition: color 0.3s;
+  min-width: 0;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  transition: var(--default-transition);
+  transition-property: color;
 }
 
 .answer:hover {
-    color: var(--secondary-dark);
-    cursor: pointer;
+  color: var(--secondary-dark);
+  cursor: pointer;
 }
 
 .answerItem {
-    height: 3.2rem;
-    width: 3.2rem;
-    border-radius: 50%;
-    background-color: var(--secondary-dark);
-    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
-    color: var(--secondary-light);
-    font-size: var(--header-3);
-    font-weight: 800;
-    text-align: center;
-    vertical-align: middle;
-    line-height: 3.2rem;
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: 2rem;
+  width: 2rem;
+  border-radius: 50%;
+  background-color: var(--secondary-dark);
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  color: var(--secondary-light);
+  font-size: var(--header-3);
+  font-weight: 800;
+  text-align: center;
+  line-height: 2rem;
 }
 
 .answerItem img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }
 
 .answerText {
-    max-width: 13rem;
-    padding-left: 0.8rem;
-    font-size: var(--question-text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  padding: 0 0.75rem;
+  font-size: var(--question-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .selected {
-    outline: 4px solid var(--secondary-dark);
-    border-radius: 1.6rem;
+  outline: 0.125rem solid var(--secondary-dark);
+  border-radius: 1.6rem;
 }

--- a/src/components/QuestionCounter/QuestionCounter.module.css
+++ b/src/components/QuestionCounter/QuestionCounter.module.css
@@ -7,7 +7,7 @@
 }
 
 .blobBox > * {
-  grid-area: 1 / -1 / 1 / -1;
+  grid-area: 1 / 1 / -1 / -1;
 }
 
 .count {

--- a/src/components/QuestionCounter/QuestionCounter.module.css
+++ b/src/components/QuestionCounter/QuestionCounter.module.css
@@ -1,6 +1,6 @@
 .blobBox {
-  width: 6.125rem;
-  height: 6.125rem;
+  width: 5rem;
+  height: 5rem;
 
   display: grid;
   place-items: center;

--- a/src/components/RankingPrompt/RankingPrompt.js
+++ b/src/components/RankingPrompt/RankingPrompt.js
@@ -3,6 +3,7 @@ import { Input } from '../Input';
 import { PopupClose } from '../PopupClose';
 import { Button } from '../Button';
 import { addUserToRanking } from '../../shared/ranking';
+import { ContentWrapper } from '../ContentWrapper';
 import styles from './RankingPrompt.module.css';
 import charactersCelebrationUrl from '../../public/img/CharactersCelebration.png';
 
@@ -50,17 +51,19 @@ function RankingPrompt({ correctAnswers, close, category, difficulty }) {
       ? `Twój wynik to ${score} punktów.`
       : `Odpowiedziałeś poprawnie na ${correctAnswers} pytań, co daje Ci ${score} punktów.`;
 
-  return html` <section class="${styles.mainBox}">
-    <div class="${styles.closeWrapper}">${PopupClose({ onClick: () => close(null) })}</div>
-    <img class="${styles.image}" src="${charactersCelebrationUrl}" alt="Characters from the show dancing." />
-    <div class=${styles.column}>
-      <header>
-        <h3 class="${styles.heading}">Gratulacje!</h3>
-        <p>${message}</p>
-      </header>
-      ${form}
-    </div>
-  </section>`;
+  return ContentWrapper({
+    topRight: PopupClose({ onClick: () => close(null) }),
+    content: html`<div class="${styles.mainBox}">
+      <img class="${styles.image}" src="${charactersCelebrationUrl}" alt="Characters from the show dancing." />
+      <div class=${styles.column}>
+        <header>
+          <h3 class="${styles.heading}">Gratulacje!</h3>
+          <p>${message}</p>
+        </header>
+        ${form}
+      </div>
+    </div>`,
+  });
 }
 
 export { RankingPrompt };

--- a/src/components/RankingPrompt/RankingPrompt.module.css
+++ b/src/components/RankingPrompt/RankingPrompt.module.css
@@ -1,25 +1,23 @@
 .mainBox {
-  color: var(--common-white);
-  background-color: var(--primary-dark);
   position: relative;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
-  gap: 3rem;
-  padding: 2rem 3.6rem 4rem 2rem;
-  border-radius: 3.125rem;
-  box-shadow: var(--popup-shadow);
+  gap: 2rem;
 }
 
 .image {
   padding: 1rem;
-  max-height: 20rem;
+  max-height: 15rem;
 }
 
 .column {
+  max-width: 20rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 3rem;
+  gap: 2rem;
 }
 
 .heading {
@@ -38,10 +36,4 @@
   flex-direction: column;
   align-items: stretch;
   gap: 1rem;
-}
-
-.closeWrapper {
-  position: absolute;
-  right: -2rem;
-  top: -2rem;
 }

--- a/src/components/RankingPrompt/RankingPrompt.module.css
+++ b/src/components/RankingPrompt/RankingPrompt.module.css
@@ -23,6 +23,8 @@
 .heading {
   font-size: var(--header-3);
   font-weight: 800;
+  filter: drop-shadow(var(--heading-shadow));
+  margin-bottom: 1rem;
 }
 
 .questionText {

--- a/src/components/RankingTable/RankingTable.module.css
+++ b/src/components/RankingTable/RankingTable.module.css
@@ -1,4 +1,4 @@
-table {
+/* table {
   color: white;
   list-style: number;
   width: 100%;
@@ -18,7 +18,7 @@ thead th:first-child {
 
 thead th:last-child {
   border-radius: 0 100px 100px 0;
-}
+} */
 
 .rankingContainer {
   overflow-y: auto;

--- a/src/components/RankingTable/RankingTable.module.css
+++ b/src/components/RankingTable/RankingTable.module.css
@@ -1,29 +1,24 @@
-/* table {
+.rankingContainer table {
   font-weight: 600;
-  color: white;
-  list-style: number;
-  width: 100%;
   text-align: center;
+  table-layout: fixed;
+  width: 100%;
 }
 
-thead th {
+.rankingContainer thead th {
   background-color: var(--primary-dark);
   color: var(--secondary-dark);
   position: sticky;
   top: 0;
+  padding: 0 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-thead th:first-child {
-  border-radius: 100px 0 0 100px;
-}
-
-thead th:last-child {
-  border-radius: 0 100px 100px 0;
-} */
 
 .rankingContainer {
-  overflow-y: auto;
-  height: 9.25rem;
+  overflow: auto;
+  height: 12rem;
 }
 
 .userScore {
@@ -32,15 +27,15 @@ thead th:last-child {
 }
 
 .blobBox {
-  width: 4.125rem;
-  height: 4.125rem;
+  width: 4rem;
+  height: 4rem;
   display: grid;
   place-items: center;
   margin: 0 auto;
 }
 
 .blobBox > * {
-  grid-area: 1 / -1 / 1 / -1;
+  grid-area: 1 / 1 / -1 / -1;
 }
 
 .userPosition {

--- a/src/components/RankingTable/RankingTable.module.css
+++ b/src/components/RankingTable/RankingTable.module.css
@@ -22,7 +22,7 @@ thead th:last-child {
 
 .rankingContainer {
   overflow-y: auto;
-  height: 31.25rem;
+  height: 9.25rem;
 }
 
 .userScore {

--- a/src/components/RulesTextBox/RulesTextBox.module.css
+++ b/src/components/RulesTextBox/RulesTextBox.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 1rem;
   height: fit-content;
-  width: 25rem;
+  width: min(25rem, 90vw);
   border-radius: 28px;
   background-color: rgba(0, 0, 0, 0.91);
   color: var(--common-white);

--- a/src/components/Timer/Timer.js
+++ b/src/components/Timer/Timer.js
@@ -45,7 +45,7 @@ function Timer({ startingMinutes, onFinish, stopTimer }) {
   const svg = html` <div class="${styles.timerOuterWrapper}">
     ${counter}
     <div class="${styles.timerInnerWrapper}">
-      <svg width="200" height="200" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="100%" height="auto" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
         <circle cx="98" cy="98" r="86.5" stroke="#B2FF59" stroke-width="15" />
         <g filter="url(#a)">
           <circle

--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -1,16 +1,13 @@
 .container {
-  display: inline-block;
-  width: auto;
-  text-align: center;
-  position: absolute;
-  top: 100%;
-  left: 100%;
-  transform: translate(-70%, -70%);
+  width: 5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 }
 
 .timerOuterWrapper {
   position: relative;
-  display: inline-block;
 }
 
 .timerInnerWrapper {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -11,3 +11,4 @@ export * from './PopupClose';
 export * from './RankingPrompt';
 export * from './RankingTable';
 export * from './AnswersTable';
+export * from './ContentWrapper';

--- a/src/pages/Answers/Answers.js
+++ b/src/pages/Answers/Answers.js
@@ -1,4 +1,4 @@
-import { Button, Logo, RankingPrompt, AnswersTable } from '../../components';
+import { Button, RankingPrompt, AnswersTable, ContentWrapper } from '../../components';
 import { html } from '../../shared';
 import styles from './Answers.module.css';
 
@@ -23,18 +23,19 @@ function Answers({ router, allAnswers, selectedCategory, selectedDifficulty }) {
     }, transitionSeconds * 1000);
   };
 
-  const rankingPrompt = RankingPrompt({
-    correctAnswers,
-    difficulty: selectedDifficulty,
-    category: selectedCategory,
-    close: closePopup,
-  });
-
-  popupOverlay.appendChild(rankingPrompt);
+  popupOverlay.appendChild(
+    RankingPrompt({
+      correctAnswers,
+      difficulty: selectedDifficulty,
+      category: selectedCategory,
+      close: closePopup,
+    }),
+  );
 
   return html`<div class="${styles.wrapper}">
-    <div class="${styles.content}">
-      <main class="${styles.container}">
+    ${ContentWrapper({
+      hasLogo: true,
+      content: html`<div class="${styles.container}">
         <h3 class="${styles.heading}">
           Poprawne odpowiedzi: <span class="${styles.score}">${correctAnswers}/${answeredQuestions}</span>
         </h3>
@@ -58,9 +59,8 @@ function Answers({ router, allAnswers, selectedCategory, selectedDifficulty }) {
             onClick: () => {},
           })}
         </div>
-        <div class="${styles.logoWrapper}">${Logo(31)}</div>
-      </main>
-    </div>
+      </div>`,
+    })}
     ${popupOverlay}
   </div>`;
 }

--- a/src/pages/Answers/Answers.module.css
+++ b/src/pages/Answers/Answers.module.css
@@ -4,7 +4,7 @@
 }
 
 .wrapper > * {
-  grid-area: 1 / -1 / 1 / -1;
+  grid-area: 1 / 1 / -1 / -1;
 }
 
 .popupOverlay {

--- a/src/pages/Answers/Answers.module.css
+++ b/src/pages/Answers/Answers.module.css
@@ -3,35 +3,21 @@
   display: grid;
 }
 
-.popupOverlay {
+.wrapper > * {
   grid-area: 1 / -1 / 1 / -1;
+}
+
+.popupOverlay {
   background-color: rgba(0, 0, 0, 0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 1;
   opacity: 1;
   transition: var(--default-transition);
-}
-
-.content {
-  grid-area: 1 / -1 / 1 / -1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
-
-  color: var(--common-white);
-  background-color: var(--primary-dark);
-  box-shadow: var(--popup-shadow);
-  padding: 4rem 4.8rem 5rem;
-  border-radius: 50px;
 }
 
 .heading {
@@ -48,11 +34,7 @@
 
 .buttonRow {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1rem;
-}
-
-.logoWrapper {
-  position: absolute;
-  top: 100%;
-  transform: translateY(-60px);
 }

--- a/src/pages/Answers/Answers.module.css
+++ b/src/pages/Answers/Answers.module.css
@@ -18,6 +18,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 1rem;
 }
 
 .heading {
@@ -25,7 +26,6 @@
   font-weight: 800;
   text-align: center;
   filter: drop-shadow(var(--heading-shadow));
-  margin-bottom: 2.4rem;
 }
 
 .score {

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -73,7 +73,7 @@ function Home({ router }) {
         ${Button({
           text: 'Ranking',
           onClick: () => {
-           router.goto({ page: 'ranking', data: { category: 'character' } });
+            router.goto({ page: 'ranking', data: { category: 'character' } });
           },
           variant: 'outlined',
         })}

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -36,55 +36,50 @@ function Home({ router }) {
     });
   };
 
-  return html`<div class="${styles.wrapper}">
-    <section class="${styles.homeSection}">
-      <div class="${styles.image}">
-        <img src="${rickAndMorty}" alt="Rick and Morty" />
-        ${rulesWrapper}
-      </div>
-      <div>
-      <div>
-        ${GameTypes({
-          onSelect: (selected) => {
-            selectedCategory = selected.id;
-            onGameOptionSelect();
-          },
-          heading: 'Wybierz kategorię',
-          categories: [
-            { id: 'character', text: 'Co to za postać' },
-            { id: 'episode', text: 'Bohaterowie odcinka' },
-            { id: 'location', text: 'Kto tu mieszka' },
-            { id: 'mixed', text: 'Mieszane' },
-          ],
-        })}
-      </div>
-
-      <div class = "${styles.difficult}">
-        ${GameTypes({
-          onSelect: (selected) => {
-            selectedDifficulty = selected.id;
-            onGameOptionSelect();
-          },
-          heading: 'Wybierz poziom',
-          categories: [
-            { id: 'easy', text: 'Łatwy' },
-            { id: 'hard', text: 'Trudny' },
-          ],
-          layout: 'halfWidth',
-        })}
-      </div>
-      <div class = "${styles.startBtn}">
-      ${btnStart}
-      ${Button({
-        text: 'Ranking',
-        onClick: () => {
-          router.goto({ page: 'ranking' });
+  return html` <section class="${styles.homeSection}">
+    <div class="${styles.image}">
+      <img src="${rickAndMorty}" alt="Rick and Morty" />
+      ${rulesWrapper}
+    </div>
+    <div class="${styles.optionsPanel}">
+      ${GameTypes({
+        onSelect: (selected) => {
+          selectedCategory = selected.id;
+          onGameOptionSelect();
         },
-        variant: 'outlined',
+        heading: 'Wybierz kategorię',
+        categories: [
+          { id: 'character', text: 'Co to za postać' },
+          { id: 'episode', text: 'Bohaterowie odcinka' },
+          { id: 'location', text: 'Kto tu mieszka' },
+          { id: 'mixed', text: 'Mieszane' },
+        ],
       })}
+      ${GameTypes({
+        onSelect: (selected) => {
+          selectedDifficulty = selected.id;
+          onGameOptionSelect();
+        },
+        heading: 'Wybierz poziom',
+        categories: [
+          { id: 'easy', text: 'Łatwy' },
+          { id: 'hard', text: 'Trudny' },
+        ],
+        layout: 'halfWidth',
+      })}
+
+      <div class="${styles.featuredButtons}">
+        ${btnStart}
+        ${Button({
+          text: 'Ranking',
+          onClick: () => {
+            router.goto({ page: 'ranking' });
+          },
+          variant: 'outlined',
+        })}
       </div>
-    </section>
-  </div></div>`;
+    </div>
+  </section>`;
 }
 
 export { Home };

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -77,7 +77,9 @@ function Home({ router }) {
       ${btnStart}
       ${Button({
         text: 'Ranking',
-        onClick: () => {},
+        onClick: () => {
+          router.goto({ page: 'ranking' });
+        },
         variant: 'outlined',
       })}
       </div>

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -1,24 +1,31 @@
-.wrapper {
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .homeSection {
-  width: 100%;
-  display: inline-flex;
+  min-height: 100vh;
+  padding: 1rem;
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 10rem;
+  align-items: center;
+  gap: 4rem;
 }
 
-.startBtn {
+.optionsPanel {
   display: flex;
-  gap: 1.25rem;
-  padding-top: 1.25rem;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex-basis: 30rem;
 }
+
+.featuredButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.featuredButtons > * {
+  flex: 1;
+}
+
 .centered {
   position: absolute;
   transform: translate(-50%, -50%);
@@ -27,7 +34,7 @@
 .image {
   width: 100%;
   height: auto;
-  max-width: 600px;
+  max-width: 30rem;
   position: relative;
   text-align: center;
 }
@@ -35,14 +42,11 @@
 .hide {
   display: none;
 }
+
 .show {
   display: block;
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-}
-
-.difficult {
-  margin-top: 3rem;
 }

--- a/src/pages/Loading/Loading.module.css
+++ b/src/pages/Loading/Loading.module.css
@@ -6,12 +6,11 @@
 }
 
 .column {
-  width: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 1.5rem;
+  gap: 1.875rem;
   color: var(--common-white);
   font-weight: 600;
 }
@@ -23,11 +22,11 @@
 
 .info {
   font-size: var(--button-text);
-  padding: 0.625rem 1.5rem;
+  padding: 0.75rem 1.875rem;
 }
 
 .minorInfo {
-  font-size: 0.9375rem;
+  font-size: 1.15rem;
 }
 
 .portalWrapper {
@@ -36,14 +35,13 @@
 
 .portal {
   width: 100%;
-  height: auto;
-  margin: 0.75rem 0;
+  margin: 0.95rem 0;
   animation: portalSpin 4s linear infinite;
 }
 
 @keyframes portalSpin {
   to {
-    transform: rotateZ(360deg);
+    transform: rotate(360deg);
   }
 }
 

--- a/src/pages/Quiz/Quiz.js
+++ b/src/pages/Quiz/Quiz.js
@@ -1,7 +1,6 @@
 import { html, render } from '../../shared';
-import { Button, Logo, BackgroundDecoration, Question, PopupClose, QuestionCounter, Timer } from '../../components';
+import { Button, Question, PopupClose, QuestionCounter, Timer, ContentWrapper } from '../../components';
 import styles from './Quiz.module.css';
-import head from '../../public/img/RicksHead.png';
 
 /**
  * @param { { generator: import('../../data/questions').QuestionGenerator, selectedCategory: import('../Loading').QuizCategory, selectedDifficulty: import('../Loading').QuizDifficulty } & import('..').RouterProps } props
@@ -20,14 +19,20 @@ function Quiz({ generator, router, ...otherProps }) {
   };
   let question = Question(generator.next().value);
 
-  return html`<div class="${styles.wrapper}">
-    ${BackgroundDecoration()}
-    <div class="${styles.quizContainer}">
-      <div class="${styles.counterElementWrapper}">${counterElement}</div>
-      <div class="${styles.popupCloseWrapper}">${PopupClose({ onClick: endQuiz })}</div>
-      <div class="${styles.headImgWrapper}">
-        <img src="${head}" alt="Ricks head" />
-      </div>
+  return ContentWrapper({
+    hasHead: true,
+    hasLogo: true,
+    hasBgDecoration: true,
+    topLeft: counterElement,
+    topRight: PopupClose({ onClick: endQuiz }),
+    botRight: Timer({
+      startingMinutes: 2,
+      onFinish: endQuiz,
+      stopTimer: (clearTimer) => {
+        finishCounting = clearTimer;
+      },
+    }),
+    content: html`<div class="${styles.quizContainer}">
       ${question.question}
       ${Button({
         onClick: (e) => {
@@ -40,16 +45,8 @@ function Quiz({ generator, router, ...otherProps }) {
         text: 'dalej',
         variant: 'nextQuestion',
       })}
-      ${Timer({
-        startingMinutes: 2,
-        onFinish: endQuiz,
-        stopTimer: (clearTimer) => {
-          finishCounting = clearTimer;
-        },
-      })}
-      <div class="${styles.logoWrapper}">${Logo(31)}</div>
-    </div>
-  </div>`;
+    </div>`,
+  });
 }
 
 export { Quiz };

--- a/src/pages/Quiz/Quiz.module.css
+++ b/src/pages/Quiz/Quiz.module.css
@@ -1,49 +1,8 @@
-.wrapper {
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .quizContainer {
-  background-color: var(--primary-dark);
-  border-radius: var(--default-border-radius);
-  width: 58.15rem;
-  min-width: 320px;
-  min-height: 400px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  padding: 3.5rem;
-  position: relative;
-}
-
-.counterElementWrapper {
-  position: absolute;
-  top: -2rem;
-  left: -2rem;
-}
-
-.popupCloseWrapper {
-  position: absolute;
-  top: -2rem;
-  right: -2rem;
-}
-
-.logoWrapper {
-  position: absolute;
-  top: 100%;
-  transform: translateY(-60px);
-}
-
-.headImgWrapper {
-  position: absolute;
-  bottom: 100%;
-  transform: translateY(50px);
-}
-
-.headImgWrapper img {
-  max-width: 100%;
-  height: auto;
+  gap: 1.5rem;
+  padding: 1rem 0;
 }

--- a/src/pages/Ranking/Ranking.js
+++ b/src/pages/Ranking/Ranking.js
@@ -1,0 +1,32 @@
+import { html } from '../../shared';
+import styles from './Ranking.module.css';
+import { RankingTable, Button } from '../../components';
+
+/**
+ * @param {{} & import('..').RouterProps} props
+ * @returns
+ */
+function Ranking({ router }) {
+  const homeBtn = Button({
+    text: 'Wróć do ekranu startowego',
+    variant: 'normal',
+    onClick: () => {
+      router.goto({ page: 'home' });
+    },
+  });
+  return html` <div class=${styles.content}>
+    <div class=${styles.flexContainer}>
+      <button class=${styles.flexBtn}>Co to za postać</button>
+      <button class=${styles.flexBtn}>Bohaterowie odcinka</button>
+      <button class=${styles.flexBtn}>Kto tu mieszka</button>
+      <button class=${styles.flexBtn}>Mieszane</button>
+    </div>
+    <div class=${styles.rectangle}>
+      <h1 class=${styles.text}>Ranking</h1>
+      <div class=${styles.table}>${RankingTable({ category: 'mixed' })}</div>
+      <div class=${styles.homeBtn}>${homeBtn}</div>
+    </div>
+  </div>`;
+}
+
+export { Ranking };

--- a/src/pages/Ranking/Ranking.js
+++ b/src/pages/Ranking/Ranking.js
@@ -1,6 +1,6 @@
 import { html, render } from '../../shared';
 import styles from './Ranking.module.css';
-import { RankingTable, Button } from '../../components';
+import { RankingTable, Button, ContentWrapper } from '../../components';
 
 /**
  * @param {{ text: string, onClick: ((e: MouseEvent) => void), id?: string, selectedCategory: QuizCategory }} props
@@ -27,18 +27,23 @@ function TabBtn({ text, onClick, id, selectedCategory }) {
  * @returns {HTMLElement}
  */
 function Ranking({ router, id, category }) {
-  const rankingTable = html`<div class=${styles.table}>${RankingTable({ id, category })}</div>`;
+  let rankingTable = RankingTable({ id, category });
+  let currentCategory = category;
 
   /**
+   * @todo there's probably a better way to implement active-tab switching
    * @param {QuizCategory} gameType
    */
   const onGameTypeSelect = (gameType) => {
-    document.getElementById(category).classList.remove(styles.flexBtnFocus);
-    render({
+    document.getElementById(currentCategory).classList.remove(styles.flexBtnFocus);
+    currentCategory = gameType;
+    document.getElementById(currentCategory).classList.add(styles.flexBtnFocus);
+
+    rankingTable = render({
       element: RankingTable({
         category: gameType,
       }),
-      on: rankingTable.firstElementChild,
+      on: rankingTable,
     });
   };
 
@@ -49,8 +54,10 @@ function Ranking({ router, id, category }) {
       router.goto({ page: 'home' });
     },
   });
-  return html` <div class=${styles.content}>
-    <div class=${styles.flexContainer}>
+
+  return ContentWrapper({
+    hasLogo: true,
+    topAttachment: html`<div class=${styles.flexContainer}>
       ${TabBtn({
         text: 'Co to za postać',
         onClick: () => {
@@ -83,13 +90,12 @@ function Ranking({ router, id, category }) {
         id: 'mixed',
         selectedCategory: category,
       })}
-    </div>
-    <div class=${styles.rectangle}>
+    </div>`,
+    content: html`<div class=${styles.rectangle}>
       <h1 class=${styles.text}>Ranking</h1>
-      ${rankingTable}
-      <div class=${styles.homeBtn}>${homeBtn}</div>
-    </div>
-  </div>`;
+      ${rankingTable} ${homeBtn}
+    </div>`,
+  });
 }
 
 export { Ranking };

--- a/src/pages/Ranking/Ranking.module.css
+++ b/src/pages/Ranking/Ranking.module.css
@@ -1,18 +1,11 @@
-.content {
-  width: 80%;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-40%, -50%);
-}
-
 .flexContainer {
   display: flex;
   text-align: center;
-  justify-content: center;
+  justify-content: stretch;
   column-gap: 0.2rem;
-  width: 80%;
+  height: 100%;
+  width: 100%;
+  overflow-x: auto;
 }
 
 .flexBtn {
@@ -20,21 +13,20 @@
   font-weight: 700;
   background-color: var(--primary-light);
   color: var(--secondary-dark);
-  display: inline-flex;
-  width: 100%;
-  height: 3rem;
-  flex-direction: column;
-  border-top-left-radius: 25px;
-  border-top-right-radius: 25px;
-  margin: 0 auto;
+  display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 10rem;
+  flex-basis: 100%;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
   cursor: pointer;
+  transition: var(--default-transition);
 }
 
 .flexBtn:hover,
-.flexBtn:active,
-.flexBtn:focus,
 .flexBtnFocus {
   box-shadow: none;
   background-color: var(--primary-dark);
@@ -42,32 +34,14 @@
 }
 
 .rectangle {
-  background-color: var(--primary-dark);
   display: flex;
   flex-direction: column;
   align-items: center;
-  border-bottom-left-radius: 25px;
-  border-bottom-right-radius: 25px;
-  width: 80%;
-  height: 500px;
-}
-
-.table {
-  margin-top: 1rem;
-  width: 80%;
+  gap: 2rem;
 }
 
 .text {
   font-weight: 800;
-  margin-left: 10%;
-  margin-right: auto;
   color: var(--common-white);
-  margin-top: 2rem;
-  font-size: 36px;
-}
-
-.homeBtn {
-  margin-top: 5%;
-  margin-left: 10%;
-  margin-right: auto;
+  font-size: var(--header-3);
 }

--- a/src/pages/Ranking/Ranking.module.css
+++ b/src/pages/Ranking/Ranking.module.css
@@ -1,0 +1,67 @@
+.content {
+  width: 80%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-40%, -50%);
+}
+
+.flexContainer {
+  display: flex;
+  text-align: center;
+  justify-content: center;
+  column-gap: 0.2rem;
+  width: 80%;
+}
+
+.flexBtn {
+  background-color: var(--primary-light);
+  color: var(--secondary-dark);
+  display: inline-flex;
+  width: 100%;
+  height: 3rem;
+  flex-direction: column;
+  border-top-left-radius: 25px;
+  border-top-right-radius: 25px;
+  margin: 0 auto;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.flexBtn:hover,
+.flexBtn:active {
+  background-color: var(--primary-dark);
+  color: var(--common-white);
+}
+
+.rectangle {
+  background-color: var(--primary-dark);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-bottom-left-radius: 25px;
+  border-bottom-right-radius: 25px;
+  width: 80%;
+  height: 500px;
+}
+
+.table {
+  margin-top: 1rem;
+  width: 80%;
+}
+
+.text {
+  margin-left: 10%;
+  margin-right: auto;
+  color: var(--common-white);
+  margin-top: 2rem;
+  font-size: 36px;
+}
+
+.homeBtn {
+  margin-top: 5%;
+  margin-left: 10%;
+  margin-right: auto;
+}

--- a/src/pages/Ranking/Ranking.module.css
+++ b/src/pages/Ranking/Ranking.module.css
@@ -37,11 +37,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 1rem;
 }
 
 .text {
-  font-weight: 800;
-  color: var(--common-white);
   font-size: var(--header-3);
+  font-weight: 800;
+  text-align: center;
+  filter: drop-shadow(var(--heading-shadow));
 }

--- a/src/pages/Ranking/index.js
+++ b/src/pages/Ranking/index.js
@@ -1,0 +1,1 @@
+export * from './Ranking';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,12 +2,14 @@ import { Home } from './Home';
 import { Loading } from './Loading';
 import { Quiz } from './Quiz';
 import { Answers } from './Answers';
+import { Ranking } from './Ranking';
 
 const pages = Object.freeze({
   home: Home,
   loading: Loading,
   quiz: Quiz,
   answers: Answers,
+  ranking: Ranking,
 });
 
 /**

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -38,7 +38,7 @@
 
   --default-border-radius: 2.5rem;
   --popup-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
-  --heading-shadow: 0px 4px 4px rgba(0, 0, 0, 0.5);
+  --heading-shadow: 0px 0.125rem 0.125rem rgba(0, 0, 0, 0.5);
   --default-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.83, 0.67);
 
   --circle-animation-time: 0;

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -34,9 +34,9 @@
   --question-text: 0.875rem;
   --question-button: 1rem;
   --button-text-small: 0.625rem;
-  --extra-big-text: 1.55rem;
+  --extra-big-text: 1.3rem;
 
-  --default-border-radius: 50px;
+  --default-border-radius: 2.5rem;
   --popup-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
   --heading-shadow: 0px 4px 4px rgba(0, 0, 0, 0.5);
   --default-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.83, 0.67);

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -56,6 +56,6 @@ body,
 
 @media screen and (min-width: 1920px) {
   :root {
-    font-size: 32px;
+    font-size: 24px;
   }
 }

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -28,14 +28,13 @@
   --action-focus: rgba(0, 0, 0, 0.12);
 
   /* Text-size styles */
-  /* base size: button-text-small (20px) */
-  --button-text: 1.6rem;
-  --header-3: 1.8rem;
-  --text-1: 1.6rem;
-  --question-text: 1.4rem;
-  --question-button: 1.6rem;
-  --button-text-small: 1rem;
-  --extra-big-text: 2.5rem;
+  --button-text: 1rem;
+  --header-3: 1.125rem;
+  --text-1: 1rem;
+  --question-text: 0.875rem;
+  --question-button: 1rem;
+  --button-text-small: 0.625rem;
+  --extra-big-text: 1.55rem;
 
   --default-border-radius: 50px;
   --popup-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
@@ -43,13 +42,20 @@
   --default-transition: all 0.3s cubic-bezier(0.17, 0.67, 0.83, 0.67);
 
   --circle-animation-time: 0;
-  font-size: 20px;
-  font-family: "Montserrat", sans-serif;
 
-  background: var(--common-dark) url("/src/public/img/background.jpg") center center / cover;
+  font-size: 16px;
+  font-family: 'Montserrat', sans-serif;
+
+  background: var(--common-dark) url('/src/public/img/background.jpg') center center / cover;
 }
 
 body,
 #app {
   min-height: 100vh;
+}
+
+@media screen and (min-width: 1920px) {
+  :root {
+    font-size: 32px;
+  }
 }


### PR DESCRIPTION
**Do zrobienia:**
- [x] style globalne
- [x] page Home
- [x] page Loading
- [x] page Quiz
- [x] page Answers
- [x] page Ranking

**Dodatkowo:**
- [x] ujednolicenie kontenera i nagłówków między ekranami
- [x] usunięcie selektorów zawierających jedynie elementy z CSS modules
- [x] wycentrowanie elementów na ekranie rankingu (wbrew temu co na Figmie, aby być zgodnym designem z resztą widoków)

**Blokowane przez:**
- ~#72~

**Załączniki:**
- [screeny.pdf](https://github.com/CodersCamp2021-HK/CodersCamp2021.Project.JavaScript/files/7803113/screeny.pdf)
PDF ze zdjęciami wszystkich widoków na różnych ekranach (po trzy na widok, dla każdego kolejno: duży 1280x720, średni 768x1024, mały 360x640).

**Dodatkowe info:**
Powinno wyglądać ok na wszystkich sensownych rozdzielczościach. W kilku miejscach musiałem zmienić minimalnie odstępy i rozmiary z Figmy, żeby były one sensowne na wszystkich rozdzielczościach.

Było testowane na:
- komputer:
  - 1920x1080
  - 1536x864
  - 1440x900
  - 1366x768
  - **1280x720** (na tej rozdzielczości prawdopodobnie będzie prezentacja)
- tablet:
  - 768x1024
- telefon:
  - 414x896
  - 375x667
  - 360x640